### PR TITLE
✨ Make timout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Flags:
     --config-dir string   Directory where config is stored. (default ".")
 -h, --help                help for vyconfigure
     --insecure            Whether to skip verifying the SSL certificate.
+    --timeout int         Timeout in seconds for API requests. (default 30)
 -v, --version             version for vyconfigure
 ```
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 func init() {
 	rootCmd.PersistentFlags().String("config-dir", ".", "Directory where config is stored.")
 	rootCmd.PersistentFlags().Bool("insecure", false, "Whether to skip verifying the SSL certificate.")
+	rootCmd.PersistentFlags().Int64("timeout", 30, "Timeout in seconds for API requests.")
 	rootCmd.Version = GetVersion()
 	rootCmd.SetVersionTemplate("{{.DisplayName}} {{.Version}}\n")
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,7 +19,7 @@ func CreateClient(o *options.Options) (*Client, error) {
 		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	httpClient := &http.Client{Transport: t, Timeout: time.Duration(10) * time.Second}
+	httpClient := &http.Client{Transport: t, Timeout: time.Duration(o.Timeout) * time.Second}
 
 	client := &Client{
 		Options:    o,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -7,13 +7,18 @@ type Options struct {
 	ApiKey          string
 	ConfigDirectory string
 	Insecure        bool
+	Timeout         int64
 }
 
 func GetOptions(cmd *cobra.Command, args []string) *Options {
+	ConfigDirectory, _ := cmd.Flags().GetString("config-dir")
+	Insecure, _ := cmd.Flags().GetBool("insecure")
+	Timeout, _ := cmd.Flags().GetInt64("timeout")
 	return &Options{
 		Host:            "https://" + args[0],
 		ApiKey:          args[1],
-		ConfigDirectory: cmd.Flag("config-dir").Value.String(),
-		Insecure:        cmd.Flag("insecure").Value.String() == "true",
+		ConfigDirectory: ConfigDirectory,
+		Insecure:        Insecure,
+		Timeout:         Timeout,
 	}
 }


### PR DESCRIPTION
Large configurations take a long time too apply and the fixed setting of 10s to timeout was too short.
This PR sets the default timeout duration to 30s and allows configuration using the `--timeout` flag.